### PR TITLE
feat: YouGile chat webhook relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@ SPREADSHEET_ID=your_spreadsheet_id_here
 YOUGILE_CHAT_ID=your_chat_id_here
 TOKEN_YOUGILE=your_token_here
 
-# Yougile webhook relay (forward messages from one chat to YOUGILE_CHAT_ID)
+# Yougile polling relay (forward messages from one chat to YOUGILE_CHAT_ID)
 YOUGILE_SUBSCRIBE_CHAT_ID=chat_id_to_watch
-YOUGILE_WEBHOOK_URL=https://your-server.com
-# Optional: set to YouGile user ID of the bot to skip its own messages
+# Poll interval in milliseconds (default: 15000 = 15 seconds)
+YOUGILE_POLL_INTERVAL_MS=15000
+# Optional: YouGile user ID of the bot to skip its own messages
 YOUGILE_BOT_USER_ID=

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ SPREADSHEET_ID=your_spreadsheet_id_here
 # Yougile Bot Configuration
 YOUGILE_CHAT_ID=your_chat_id_here
 TOKEN_YOUGILE=your_token_here
+
+# Yougile webhook relay (forward messages from one chat to YOUGILE_CHAT_ID)
+YOUGILE_SUBSCRIBE_CHAT_ID=chat_id_to_watch
+YOUGILE_WEBHOOK_URL=https://your-server.com
+# Optional: set to YouGile user ID of the bot to skip its own messages
+YOUGILE_BOT_USER_ID=

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,14 @@
+// Returns credential value or fallback if the credential doesn't exist
+def getOptionalCredential(credId, fallback = '') {
+    try {
+        withCredentials([string(credentialsId: credId, variable: 'OPT_CRED')]) {
+            return env.OPT_CRED ?: fallback
+        }
+    } catch (e) {
+        return fallback
+    }
+}
+
 // Helper function to wait for container readiness
 def waitForContainer(containerName, maxWaitSeconds = 30) {
     def startTime = System.currentTimeMillis()
@@ -32,14 +43,15 @@ def deployShops(shopsList, imageTag) {
         def shopPort = env."${shop.toUpperCase()}_PORT"
         echo "Deploying ${shop} on port ${shopPort}"
 
+        def subscribeChat = getOptionalCredential("${shop}-yougile-subscribe-chat-id")
+        def pollInterval  = getOptionalCredential("${shop}-yougile-poll-interval-ms", '15000')
+        def botUserId     = getOptionalCredential("${shop}-yougile-bot-user-id")
+
         withCredentials([
             string(credentialsId: "${shop}-spreadsheet-id", variable: 'SHOP_SPREADSHEET_ID'),
             file(credentialsId: 'service-account', variable: 'GOOGLE_SERVICE_ACCOUNT_FILE'),
             string(credentialsId: "${shop}-token-yougile", variable: 'TOKEN_YOUGILE'),
             string(credentialsId: "${shop}-yougile-chat-id", variable: 'YOUGILE_CHAT_ID'),
-            string(credentialsId: "${shop}-yougile-subscribe-chat-id", variable: 'YOUGILE_SUBSCRIBE_CHAT_ID', defaultValue: ''),
-            string(credentialsId: "${shop}-yougile-poll-interval-ms", variable: 'YOUGILE_POLL_INTERVAL_MS', defaultValue: '15000'),
-            string(credentialsId: "${shop}-yougile-bot-user-id", variable: 'YOUGILE_BOT_USER_ID', defaultValue: ''),
         ]) {
             sh """
                 docker rm -f ${shop}_backend_container || true
@@ -54,9 +66,9 @@ def deployShops(shopsList, imageTag) {
                     -e SPREADSHEET_ID=\$SHOP_SPREADSHEET_ID \\
                     -e TOKEN_YOUGILE=\$TOKEN_YOUGILE \\
                     -e YOUGILE_CHAT_ID=\$YOUGILE_CHAT_ID \\
-                    -e YOUGILE_SUBSCRIBE_CHAT_ID=\$YOUGILE_SUBSCRIBE_CHAT_ID \\
-                    -e YOUGILE_POLL_INTERVAL_MS=\$YOUGILE_POLL_INTERVAL_MS \\
-                    -e YOUGILE_BOT_USER_ID=\$YOUGILE_BOT_USER_ID \\
+                    -e YOUGILE_SUBSCRIBE_CHAT_ID=${subscribeChat} \\
+                    -e YOUGILE_POLL_INTERVAL_MS=${pollInterval} \\
+                    -e YOUGILE_BOT_USER_ID=${botUserId} \\
                     \$DOCKER_REGISTRY/\$IMAGE_NAME:${imageTag}
             """
         }
@@ -163,14 +175,15 @@ pipeline {
                             def shopPort = env."${shop.toUpperCase()}_PORT"
                             echo "Deploying ${shop} for testing on port ${shopPort}"
 
+                            def subscribeChat = getOptionalCredential("${shop}-yougile-subscribe-chat-id")
+                            def pollInterval  = getOptionalCredential("${shop}-yougile-poll-interval-ms", '15000')
+                            def botUserId     = getOptionalCredential("${shop}-yougile-bot-user-id")
+
                             withCredentials([
                                 string(credentialsId: "${shop}-spreadsheet-id", variable: 'SHOP_SPREADSHEET_ID'),
                                 file(credentialsId: 'service-account', variable: 'GOOGLE_SERVICE_ACCOUNT_FILE'),
                                 string(credentialsId: "${shop}-token-yougile", variable: 'TOKEN_YOUGILE'),
                                 string(credentialsId: "${shop}-yougile-chat-id", variable: 'YOUGILE_CHAT_ID'),
-                                string(credentialsId: "${shop}-yougile-subscribe-chat-id", variable: 'YOUGILE_SUBSCRIBE_CHAT_ID', defaultValue: ''),
-                                string(credentialsId: "${shop}-yougile-poll-interval-ms", variable: 'YOUGILE_POLL_INTERVAL_MS', defaultValue: '15000'),
-                                string(credentialsId: "${shop}-yougile-bot-user-id", variable: 'YOUGILE_BOT_USER_ID', defaultValue: ''),
                             ]) {
                                 sh """
                                     docker rm -f ${shop}_backend_container || true
@@ -182,9 +195,9 @@ pipeline {
                                         -e SPREADSHEET_ID=\$SHOP_SPREADSHEET_ID \\
                                         -e TOKEN_YOUGILE=\$TOKEN_YOUGILE \\
                                         -e YOUGILE_CHAT_ID=\$YOUGILE_CHAT_ID \\
-                                        -e YOUGILE_SUBSCRIBE_CHAT_ID=\$YOUGILE_SUBSCRIBE_CHAT_ID \\
-                                        -e YOUGILE_POLL_INTERVAL_MS=\$YOUGILE_POLL_INTERVAL_MS \\
-                                        -e YOUGILE_BOT_USER_ID=\$YOUGILE_BOT_USER_ID \\
+                                        -e YOUGILE_SUBSCRIBE_CHAT_ID=${subscribeChat} \\
+                                        -e YOUGILE_POLL_INTERVAL_MS=${pollInterval} \\
+                                        -e YOUGILE_BOT_USER_ID=${botUserId} \\
                                         \$DOCKER_REGISTRY/\$IMAGE_NAME:\$DOCKER_IMAGE_TAG
                                 """
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ def deployShops(shopsList, imageTag) {
             string(credentialsId: "${shop}-token-yougile", variable: 'TOKEN_YOUGILE'),
             string(credentialsId: "${shop}-yougile-chat-id", variable: 'YOUGILE_CHAT_ID'),
             string(credentialsId: "${shop}-yougile-subscribe-chat-id", variable: 'YOUGILE_SUBSCRIBE_CHAT_ID', defaultValue: ''),
-            string(credentialsId: "${shop}-yougile-webhook-url", variable: 'YOUGILE_WEBHOOK_URL', defaultValue: ''),
+            string(credentialsId: "${shop}-yougile-poll-interval-ms", variable: 'YOUGILE_POLL_INTERVAL_MS', defaultValue: '15000'),
             string(credentialsId: "${shop}-yougile-bot-user-id", variable: 'YOUGILE_BOT_USER_ID', defaultValue: ''),
         ]) {
             sh """
@@ -53,7 +53,7 @@ def deployShops(shopsList, imageTag) {
                     -e TOKEN_YOUGILE=\$TOKEN_YOUGILE \\
                     -e YOUGILE_CHAT_ID=\$YOUGILE_CHAT_ID \\
                     -e YOUGILE_SUBSCRIBE_CHAT_ID=\$YOUGILE_SUBSCRIBE_CHAT_ID \\
-                    -e YOUGILE_WEBHOOK_URL=\$YOUGILE_WEBHOOK_URL \\
+                    -e YOUGILE_POLL_INTERVAL_MS=\$YOUGILE_POLL_INTERVAL_MS \\
                     -e YOUGILE_BOT_USER_ID=\$YOUGILE_BOT_USER_ID \\
                     \$DOCKER_REGISTRY/\$IMAGE_NAME:${imageTag}
             """
@@ -167,7 +167,7 @@ pipeline {
                                 string(credentialsId: "${shop}-token-yougile", variable: 'TOKEN_YOUGILE'),
                                 string(credentialsId: "${shop}-yougile-chat-id", variable: 'YOUGILE_CHAT_ID'),
                                 string(credentialsId: "${shop}-yougile-subscribe-chat-id", variable: 'YOUGILE_SUBSCRIBE_CHAT_ID', defaultValue: ''),
-                                string(credentialsId: "${shop}-yougile-webhook-url", variable: 'YOUGILE_WEBHOOK_URL', defaultValue: ''),
+                                string(credentialsId: "${shop}-yougile-poll-interval-ms", variable: 'YOUGILE_POLL_INTERVAL_MS', defaultValue: '15000'),
                                 string(credentialsId: "${shop}-yougile-bot-user-id", variable: 'YOUGILE_BOT_USER_ID', defaultValue: ''),
                             ]) {
                                 sh """
@@ -181,7 +181,7 @@ pipeline {
                                         -e TOKEN_YOUGILE=\$TOKEN_YOUGILE \\
                                         -e YOUGILE_CHAT_ID=\$YOUGILE_CHAT_ID \\
                                         -e YOUGILE_SUBSCRIBE_CHAT_ID=\$YOUGILE_SUBSCRIBE_CHAT_ID \\
-                                        -e YOUGILE_WEBHOOK_URL=\$YOUGILE_WEBHOOK_URL \\
+                                        -e YOUGILE_POLL_INTERVAL_MS=\$YOUGILE_POLL_INTERVAL_MS \\
                                         -e YOUGILE_BOT_USER_ID=\$YOUGILE_BOT_USER_ID \\
                                         \$DOCKER_REGISTRY/\$IMAGE_NAME:\$DOCKER_IMAGE_TAG
                                 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,9 @@ def deployShops(shopsList, imageTag) {
             file(credentialsId: 'service-account', variable: 'GOOGLE_SERVICE_ACCOUNT_FILE'),
             string(credentialsId: "${shop}-token-yougile", variable: 'TOKEN_YOUGILE'),
             string(credentialsId: "${shop}-yougile-chat-id", variable: 'YOUGILE_CHAT_ID'),
+            string(credentialsId: "${shop}-yougile-subscribe-chat-id", variable: 'YOUGILE_SUBSCRIBE_CHAT_ID', defaultValue: ''),
+            string(credentialsId: "${shop}-yougile-webhook-url", variable: 'YOUGILE_WEBHOOK_URL', defaultValue: ''),
+            string(credentialsId: "${shop}-yougile-bot-user-id", variable: 'YOUGILE_BOT_USER_ID', defaultValue: ''),
         ]) {
             sh """
                 docker rm -f ${shop}_backend_container || true
@@ -49,6 +52,9 @@ def deployShops(shopsList, imageTag) {
                     -e SPREADSHEET_ID=\$SHOP_SPREADSHEET_ID \\
                     -e TOKEN_YOUGILE=\$TOKEN_YOUGILE \\
                     -e YOUGILE_CHAT_ID=\$YOUGILE_CHAT_ID \\
+                    -e YOUGILE_SUBSCRIBE_CHAT_ID=\$YOUGILE_SUBSCRIBE_CHAT_ID \\
+                    -e YOUGILE_WEBHOOK_URL=\$YOUGILE_WEBHOOK_URL \\
+                    -e YOUGILE_BOT_USER_ID=\$YOUGILE_BOT_USER_ID \\
                     \$DOCKER_REGISTRY/\$IMAGE_NAME:${imageTag}
             """
         }
@@ -160,6 +166,9 @@ pipeline {
                                 file(credentialsId: 'service-account', variable: 'GOOGLE_SERVICE_ACCOUNT_FILE'),
                                 string(credentialsId: "${shop}-token-yougile", variable: 'TOKEN_YOUGILE'),
                                 string(credentialsId: "${shop}-yougile-chat-id", variable: 'YOUGILE_CHAT_ID'),
+                                string(credentialsId: "${shop}-yougile-subscribe-chat-id", variable: 'YOUGILE_SUBSCRIBE_CHAT_ID', defaultValue: ''),
+                                string(credentialsId: "${shop}-yougile-webhook-url", variable: 'YOUGILE_WEBHOOK_URL', defaultValue: ''),
+                                string(credentialsId: "${shop}-yougile-bot-user-id", variable: 'YOUGILE_BOT_USER_ID', defaultValue: ''),
                             ]) {
                                 sh """
                                     docker rm -f ${shop}_backend_container || true
@@ -171,6 +180,9 @@ pipeline {
                                         -e SPREADSHEET_ID=\$SHOP_SPREADSHEET_ID \\
                                         -e TOKEN_YOUGILE=\$TOKEN_YOUGILE \\
                                         -e YOUGILE_CHAT_ID=\$YOUGILE_CHAT_ID \\
+                                        -e YOUGILE_SUBSCRIBE_CHAT_ID=\$YOUGILE_SUBSCRIBE_CHAT_ID \\
+                                        -e YOUGILE_WEBHOOK_URL=\$YOUGILE_WEBHOOK_URL \\
+                                        -e YOUGILE_BOT_USER_ID=\$YOUGILE_BOT_USER_ID \\
                                         \$DOCKER_REGISTRY/\$IMAGE_NAME:\$DOCKER_IMAGE_TAG
                                 """
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,10 +43,12 @@ def deployShops(shopsList, imageTag) {
         ]) {
             sh """
                 docker rm -f ${shop}_backend_container || true
+                mkdir -p /opt/cashbook/${shop}
                 docker run --name ${shop}_backend_container \\
                     --network cashbook-network \\
                     --restart unless-stopped \\
                     -d -p 0.0.0.0:${shopPort}:${shopPort} \\
+                    -v /opt/cashbook/${shop}:/app/data \\
                     -e PORT=${shopPort} \\
                     -e GOOGLE_SERVICE_ACCOUNT_JSON="\$(cat \$GOOGLE_SERVICE_ACCOUNT_FILE)" \\
                     -e SPREADSHEET_ID=\$SHOP_SPREADSHEET_ID \\

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,131 +97,117 @@ const auth = new google.auth.GoogleAuth({
 const sheets = google.sheets({ version: 'v4', auth });
 const SPREADSHEET_ID = process.env.SPREADSHEET_ID;
 
-// ── YouGile webhook relay ────────────────────────────────────────────────────
+// ── YouGile chat polling relay ───────────────────────────────────────────────
 
-interface YouGileWebhookPayload {
-    event?: string;
-    type?: string;
-    object?: YouGileMessageObject;
-    data?: YouGileMessageObject;
-    [key: string]: any;
-}
-
-interface YouGileMessageObject {
-    id?: string | number;
+interface YouGileMessage {
+    id: string | number;
     text?: string;
     textHtml?: string;
     fromUserId?: string;
-    from_user_id?: string;
-    chatId?: string;
-    chat_id?: string;
     deleted?: boolean;
-    [key: string]: any;
 }
 
-async function setupYougileWebhook(): Promise<void> {
+interface YouGileMessagesResponse {
+    content?: YouGileMessage[];
+}
+
+let lastSeenMessageId: number | null = null;
+
+async function pollYougileMessages(): Promise<void> {
     const subscribeChat = process.env.YOUGILE_SUBSCRIBE_CHAT_ID;
-    const webhookBaseUrl = process.env.YOUGILE_WEBHOOK_URL;
-    const token = process.env.TOKEN_YOUGILE;
-
-    if (!subscribeChat || !webhookBaseUrl || !token) {
-        console.warn('⚠️  YouGile webhook relay не настроен: укажите YOUGILE_SUBSCRIBE_CHAT_ID и YOUGILE_WEBHOOK_URL');
-        return;
-    }
-
-    const webhookEndpoint = `${webhookBaseUrl.replace(/\/$/, '')}/api/yougile-webhook`;
-
-    try {
-        // Check existing webhooks to avoid duplicates
-        const listResp = await fetch('https://ru.yougile.com/api-v2/webhooks', {
-            headers: { 'Authorization': `Bearer ${token}` }
-        });
-
-        if (listResp.ok) {
-            const listData = await listResp.json() as { content?: any[] };
-            const existing = (listData.content || listData as any[]).find?.(
-                (w: any) => w.url === webhookEndpoint && w.event === 'chat_message-created' && !w.deleted
-            );
-            if (existing) {
-                console.log(`✅ YouGile webhook уже зарегистрирован (id: ${existing.id})`);
-                return;
-            }
-        }
-
-        // Register new webhook
-        const createResp = await fetch('https://ru.yougile.com/api-v2/webhooks', {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                url: webhookEndpoint,
-                event: 'chat_message-created',
-                filters: [
-                    { name: 'location', value: [subscribeChat] }
-                ]
-            })
-        });
-
-        const result = await createResp.json() as { id?: string };
-        if (createResp.status === 201 && result.id) {
-            console.log(`✅ YouGile webhook зарегистрирован (id: ${result.id}), слушаем чат: ${subscribeChat}`);
-        } else {
-            console.error('❌ Ошибка регистрации YouGile webhook:', result);
-        }
-    } catch (err: any) {
-        console.error('❌ Не удалось настроить YouGile webhook:', err.message);
-    }
-}
-
-// Webhook endpoint — receives YouGile events
-app.post('/api/yougile-webhook', async (req, res) => {
-    // Respond immediately so YouGile doesn't retry
-    res.status(200).json({ ok: true });
-
-    const payload = req.body as YouGileWebhookPayload;
     const token = process.env.TOKEN_YOUGILE;
     const targetChatId = process.env.YOUGILE_CHAT_ID;
     const botUserId = process.env.YOUGILE_BOT_USER_ID;
 
-    if (!token || !targetChatId) return;
-
-    // Normalise payload — YouGile may wrap the object in different fields
-    const msgData: YouGileMessageObject = payload.object || payload.data || payload;
-    const fromUserId: string | undefined = msgData.fromUserId || msgData.from_user_id;
-    const text: string = msgData.text || '';
-    const textHtml: string = msgData.textHtml || '';
-
-    // Skip deleted messages or empty text
-    if (msgData.deleted || (!text && !textHtml)) return;
-
-    // Skip messages sent by the bot itself
-    if (botUserId && fromUserId && fromUserId === botUserId) return;
-
-    console.log(`📨 YouGile relay: сообщение от ${fromUserId ?? 'unknown'} → пересылаем в ${targetChatId}`);
+    if (!subscribeChat || !token || !targetChatId) return;
 
     try {
-        const fwdResp = await fetch(`https://ru.yougile.com/api-v2/chats/${targetChatId}/messages`, {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${token}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                text: text || 'forwarded message',
-                ...(textHtml ? { textHtml } : {})
-            })
-        });
+        const resp = await fetch(
+            `https://ru.yougile.com/api-v2/chats/${subscribeChat}/messages?limit=50`,
+            { headers: { 'Authorization': `Bearer ${token}` } }
+        );
 
-        if (!fwdResp.ok) {
-            const errBody = await fwdResp.text();
-            console.error(`❌ Ошибка пересылки сообщения (${fwdResp.status}):`, errBody);
+        if (!resp.ok) {
+            console.error(`❌ YouGile poll ошибка (${resp.status})`);
+            return;
+        }
+
+        const data = await resp.json() as YouGileMessagesResponse | YouGileMessage[];
+        const messages: YouGileMessage[] = Array.isArray(data)
+            ? data
+            : (data as YouGileMessagesResponse).content ?? [];
+
+        if (messages.length === 0) return;
+
+        const toNumber = (id: string | number): number =>
+            typeof id === 'string' ? parseInt(id, 10) : id;
+
+        const maxId = messages.reduce((max, m) => Math.max(max, toNumber(m.id)), 0);
+
+        // First poll — set baseline, don't forward old messages
+        if (lastSeenMessageId === null) {
+            lastSeenMessageId = maxId;
+            console.log(`✅ YouGile polling запущен, последнее сообщение id=${lastSeenMessageId}`);
+            return;
+        }
+
+        const newMessages = messages
+            .filter(m => toNumber(m.id) > lastSeenMessageId!)
+            .sort((a, b) => toNumber(a.id) - toNumber(b.id)); // oldest first
+
+        if (newMessages.length === 0) return;
+
+        lastSeenMessageId = maxId;
+
+        for (const msg of newMessages) {
+            if (msg.deleted || (!msg.text && !msg.textHtml)) continue;
+            if (botUserId && msg.fromUserId === botUserId) continue;
+
+            console.log(`📨 YouGile relay: id=${msg.id} от ${msg.fromUserId ?? 'unknown'} → ${targetChatId}`);
+
+            try {
+                const fwdResp = await fetch(
+                    `https://ru.yougile.com/api-v2/chats/${targetChatId}/messages`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bearer ${token}`,
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({
+                            text: msg.text || 'forwarded message',
+                            ...(msg.textHtml ? { textHtml: msg.textHtml } : {})
+                        })
+                    }
+                );
+
+                if (!fwdResp.ok) {
+                    console.error(`❌ Ошибка пересылки (${fwdResp.status}):`, await fwdResp.text());
+                }
+            } catch (err: any) {
+                console.error('❌ Не удалось переслать сообщение:', err.message);
+            }
         }
     } catch (err: any) {
-        console.error('❌ Не удалось переслать сообщение:', err.message);
+        console.error('❌ YouGile polling error:', err.message);
     }
-});
+}
+
+function startYougilePolling(): void {
+    const subscribeChat = process.env.YOUGILE_SUBSCRIBE_CHAT_ID;
+    const token = process.env.TOKEN_YOUGILE;
+    const targetChatId = process.env.YOUGILE_CHAT_ID;
+
+    if (!subscribeChat || !token || !targetChatId) {
+        console.warn('⚠️  YouGile polling не настроен: укажите YOUGILE_SUBSCRIBE_CHAT_ID');
+        return;
+    }
+
+    const intervalMs = parseInt(process.env.YOUGILE_POLL_INTERVAL_MS || '15000', 10);
+    pollYougileMessages();
+    setInterval(pollYougileMessages, intervalMs);
+    console.log(`🔄 YouGile polling запущен (каждые ${intervalMs / 1000}с), чат: ${subscribeChat}`);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -467,10 +453,10 @@ const server = app.listen(PORT, '0.0.0.0', () => {
     console.log(`- YOUGILE_CHAT_ID: ${process.env.YOUGILE_CHAT_ID ? 'Set' : 'Not set'}`);
     console.log(`- TOKEN_YOUGILE: ${process.env.TOKEN_YOUGILE ? 'Set' : 'Not set'}`);
     console.log(`- YOUGILE_SUBSCRIBE_CHAT_ID: ${process.env.YOUGILE_SUBSCRIBE_CHAT_ID ? 'Set' : 'Not set'}`);
-    console.log(`- YOUGILE_WEBHOOK_URL: ${process.env.YOUGILE_WEBHOOK_URL || 'Not set'}`);
+    console.log(`- YOUGILE_POLL_INTERVAL_MS: ${process.env.YOUGILE_POLL_INTERVAL_MS || '15000 (default)'}`);
     console.log(`- YOUGILE_BOT_USER_ID: ${process.env.YOUGILE_BOT_USER_ID ? 'Set' : 'Not set (all messages will be forwarded)'}`);
 
-    setupYougileWebhook();
+    startYougilePolling();
 
     // Check if service account file exists
     try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,7 +111,28 @@ interface YouGileMessagesResponse {
     content?: YouGileMessage[];
 }
 
-let lastSeenMessageId: number | null = null;
+const POLL_STATE_FILE = path.join(__dirname, '../data/yougile_poll_state.json');
+
+function loadLastSeenId(): number | null {
+    try {
+        const raw = fs.readFileSync(POLL_STATE_FILE, 'utf8');
+        const parsed = JSON.parse(raw);
+        return typeof parsed.lastSeenMessageId === 'number' ? parsed.lastSeenMessageId : null;
+    } catch {
+        return null;
+    }
+}
+
+function saveLastSeenId(id: number): void {
+    try {
+        fs.mkdirSync(path.dirname(POLL_STATE_FILE), { recursive: true });
+        fs.writeFileSync(POLL_STATE_FILE, JSON.stringify({ lastSeenMessageId: id }), 'utf8');
+    } catch (err: any) {
+        console.error('❌ Не удалось сохранить состояние polling:', err.message);
+    }
+}
+
+let lastSeenMessageId: number | null = loadLastSeenId();
 
 async function pollYougileMessages(): Promise<void> {
     const subscribeChat = process.env.YOUGILE_SUBSCRIBE_CHAT_ID;
@@ -144,10 +165,11 @@ async function pollYougileMessages(): Promise<void> {
 
         const maxId = messages.reduce((max, m) => Math.max(max, toNumber(m.id)), 0);
 
-        // First poll — set baseline, don't forward old messages
+        // First ever launch — set baseline so we don't flood with history
         if (lastSeenMessageId === null) {
             lastSeenMessageId = maxId;
-            console.log(`✅ YouGile polling запущен, последнее сообщение id=${lastSeenMessageId}`);
+            saveLastSeenId(maxId);
+            console.log(`✅ YouGile polling запущен впервые, baseline id=${lastSeenMessageId}`);
             return;
         }
 
@@ -157,7 +179,9 @@ async function pollYougileMessages(): Promise<void> {
 
         if (newMessages.length === 0) return;
 
+        // Update persisted state before forwarding to avoid re-sending on crash
         lastSeenMessageId = maxId;
+        saveLastSeenId(maxId);
 
         for (const msg of newMessages) {
             if (msg.deleted || (!msg.text && !msg.textHtml)) continue;

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,6 +97,134 @@ const auth = new google.auth.GoogleAuth({
 const sheets = google.sheets({ version: 'v4', auth });
 const SPREADSHEET_ID = process.env.SPREADSHEET_ID;
 
+// ── YouGile webhook relay ────────────────────────────────────────────────────
+
+interface YouGileWebhookPayload {
+    event?: string;
+    type?: string;
+    object?: YouGileMessageObject;
+    data?: YouGileMessageObject;
+    [key: string]: any;
+}
+
+interface YouGileMessageObject {
+    id?: string | number;
+    text?: string;
+    textHtml?: string;
+    fromUserId?: string;
+    from_user_id?: string;
+    chatId?: string;
+    chat_id?: string;
+    deleted?: boolean;
+    [key: string]: any;
+}
+
+async function setupYougileWebhook(): Promise<void> {
+    const subscribeChat = process.env.YOUGILE_SUBSCRIBE_CHAT_ID;
+    const webhookBaseUrl = process.env.YOUGILE_WEBHOOK_URL;
+    const token = process.env.TOKEN_YOUGILE;
+
+    if (!subscribeChat || !webhookBaseUrl || !token) {
+        console.warn('⚠️  YouGile webhook relay не настроен: укажите YOUGILE_SUBSCRIBE_CHAT_ID и YOUGILE_WEBHOOK_URL');
+        return;
+    }
+
+    const webhookEndpoint = `${webhookBaseUrl.replace(/\/$/, '')}/api/yougile-webhook`;
+
+    try {
+        // Check existing webhooks to avoid duplicates
+        const listResp = await fetch('https://ru.yougile.com/api-v2/webhooks', {
+            headers: { 'Authorization': `Bearer ${token}` }
+        });
+
+        if (listResp.ok) {
+            const listData = await listResp.json() as { content?: any[] };
+            const existing = (listData.content || listData as any[]).find?.(
+                (w: any) => w.url === webhookEndpoint && w.event === 'chat_message-created' && !w.deleted
+            );
+            if (existing) {
+                console.log(`✅ YouGile webhook уже зарегистрирован (id: ${existing.id})`);
+                return;
+            }
+        }
+
+        // Register new webhook
+        const createResp = await fetch('https://ru.yougile.com/api-v2/webhooks', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                url: webhookEndpoint,
+                event: 'chat_message-created',
+                filters: [
+                    { name: 'location', value: [subscribeChat] }
+                ]
+            })
+        });
+
+        const result = await createResp.json() as { id?: string };
+        if (createResp.status === 201 && result.id) {
+            console.log(`✅ YouGile webhook зарегистрирован (id: ${result.id}), слушаем чат: ${subscribeChat}`);
+        } else {
+            console.error('❌ Ошибка регистрации YouGile webhook:', result);
+        }
+    } catch (err: any) {
+        console.error('❌ Не удалось настроить YouGile webhook:', err.message);
+    }
+}
+
+// Webhook endpoint — receives YouGile events
+app.post('/api/yougile-webhook', async (req, res) => {
+    // Respond immediately so YouGile doesn't retry
+    res.status(200).json({ ok: true });
+
+    const payload = req.body as YouGileWebhookPayload;
+    const token = process.env.TOKEN_YOUGILE;
+    const targetChatId = process.env.YOUGILE_CHAT_ID;
+    const botUserId = process.env.YOUGILE_BOT_USER_ID;
+
+    if (!token || !targetChatId) return;
+
+    // Normalise payload — YouGile may wrap the object in different fields
+    const msgData: YouGileMessageObject = payload.object || payload.data || payload;
+    const fromUserId: string | undefined = msgData.fromUserId || msgData.from_user_id;
+    const text: string = msgData.text || '';
+    const textHtml: string = msgData.textHtml || '';
+
+    // Skip deleted messages or empty text
+    if (msgData.deleted || (!text && !textHtml)) return;
+
+    // Skip messages sent by the bot itself
+    if (botUserId && fromUserId && fromUserId === botUserId) return;
+
+    console.log(`📨 YouGile relay: сообщение от ${fromUserId ?? 'unknown'} → пересылаем в ${targetChatId}`);
+
+    try {
+        const fwdResp = await fetch(`https://ru.yougile.com/api-v2/chats/${targetChatId}/messages`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                text: text || 'forwarded message',
+                ...(textHtml ? { textHtml } : {})
+            })
+        });
+
+        if (!fwdResp.ok) {
+            const errBody = await fwdResp.text();
+            console.error(`❌ Ошибка пересылки сообщения (${fwdResp.status}):`, errBody);
+        }
+    } catch (err: any) {
+        console.error('❌ Не удалось переслать сообщение:', err.message);
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 // Routes
 app.post('/api/shift-data', upload.single('screenshot'), async (req, res) => {
     try {
@@ -338,6 +466,11 @@ const server = app.listen(PORT, '0.0.0.0', () => {
     console.log(`- SPREADSHEET_ID: ${process.env.SPREADSHEET_ID}`);
     console.log(`- YOUGILE_CHAT_ID: ${process.env.YOUGILE_CHAT_ID ? 'Set' : 'Not set'}`);
     console.log(`- TOKEN_YOUGILE: ${process.env.TOKEN_YOUGILE ? 'Set' : 'Not set'}`);
+    console.log(`- YOUGILE_SUBSCRIBE_CHAT_ID: ${process.env.YOUGILE_SUBSCRIBE_CHAT_ID ? 'Set' : 'Not set'}`);
+    console.log(`- YOUGILE_WEBHOOK_URL: ${process.env.YOUGILE_WEBHOOK_URL || 'Not set'}`);
+    console.log(`- YOUGILE_BOT_USER_ID: ${process.env.YOUGILE_BOT_USER_ID ? 'Set' : 'Not set (all messages will be forwarded)'}`);
+
+    setupYougileWebhook();
 
     // Check if service account file exists
     try {


### PR DESCRIPTION
## Summary

- Adds a webhook subscription to a YouGile chat (configured via `YOUGILE_SUBSCRIBE_CHAT_ID`) that is registered automatically on server startup
- Incoming messages from all participants **except the bot itself** are forwarded to the existing `YOUGILE_CHAT_ID`
- Duplicate webhook registration is prevented on restarts (checks existing subscriptions before creating)

## What changed

### `src/server.ts`
- `setupYougileWebhook()` — called on server start; registers a `chat_message-created` webhook with a `location` filter for `YOUGILE_SUBSCRIBE_CHAT_ID`
- `POST /api/yougile-webhook` — receives YouGile events, filters out bot messages and deleted/empty messages, forwards the rest to `YOUGILE_CHAT_ID`

### `Jenkinsfile`
- Both test and production `docker run` blocks now pass three new optional credentials: `YOUGILE_SUBSCRIBE_CHAT_ID`, `YOUGILE_WEBHOOK_URL`, `YOUGILE_BOT_USER_ID`
- Uses `defaultValue: ''` so existing shops without these credentials continue to work unchanged

### `.env.example`
- Documents the three new env variables

## New environment variables

| Variable | Required | Description |
|---|---|---|
| `YOUGILE_SUBSCRIBE_CHAT_ID` | Yes (for relay) | ID of the YouGile chat to watch |
| `YOUGILE_WEBHOOK_URL` | Yes (for relay) | Public base URL of this server (e.g. `http://123.45.67.89:5000`) |
| `YOUGILE_BOT_USER_ID` | No | YouGile user ID of the bot — messages from this user are not forwarded |

## Jenkins setup required

Add three **Secret text** credentials per shop in Jenkins → Manage Jenkins → Credentials:
- `{shop}-yougile-subscribe-chat-id`
- `{shop}-yougile-webhook-url`
- `{shop}-yougile-bot-user-id`

If credentials are absent the server starts normally and logs a warning — no relay runs.